### PR TITLE
add; Lazy support for Type Annotations

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -670,7 +670,7 @@ class Website(models.Model):
                 return False
 
         # dont't list routes without argument having no default value or converter
-        spec = inspect.getargspec(endpoint.method.original_func)
+        spec = inspect.getfullargspec(endpoint.method.original_func)
 
         # remove self and arguments having a default value
         defaults_count = len(spec.defaults or [])

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -48,7 +48,7 @@ __all__ = [
 import logging
 from collections import defaultdict, Mapping
 from contextlib import contextmanager
-from inspect import currentframe, getargspec
+from inspect import currentframe, getfullargspec
 from pprint import pformat
 from weakref import WeakSet
 
@@ -277,7 +277,7 @@ def downgrade(method, value, self, args, kwargs):
     if not spec:
         return value
     _, convert, _ = spec
-    if convert and len(getargspec(convert).args) > 1:
+    if convert and len(getfullargspec(convert).args) > 1:
         return convert(self, value, *args, **kwargs)
     elif convert:
         return convert(value)
@@ -302,7 +302,7 @@ def split_context(method, args, kwargs):
     """ Extract the context from a pair of positional and keyword arguments.
         Return a triple ``context, args, kwargs``.
     """
-    pos = len(getargspec(method).args) - 1
+    pos = len(getfullargspec(method).args) - 1
     if pos < len(args):
         return args[pos], args[:pos], kwargs
     else:
@@ -687,7 +687,8 @@ def guess(method):
         return method
 
     # introspection on argument names to determine api style
-    args, vname, kwname, defaults = getargspec(method)
+    # Changed implementation for lazy support to Type Annotations
+    args, vname, kwname, defaults, kwonlyargs, kwonlydefaults, ann = getfullargspec(method)
     names = tuple(args) + (None,) * 4
 
     if names[0] == 'self':

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -304,7 +304,7 @@ class WebRequest(object):
     def _handle_exception(self, exception):
         """Called within an except block to allow converting exceptions
            to abitrary responses. Anything returned (except None) will
-           be used as response.""" 
+           be used as response."""
         self._failed = exception # prevent tx commit
         if not isinstance(exception, NO_POSTMORTEM) \
                 and not isinstance(exception, werkzeug.exceptions.HTTPException):
@@ -589,7 +589,7 @@ class JsonRequest(WebRequest):
         self.jsonp = jsonp
         request = None
         request_id = args.get('id')
-        
+
         if jsonp and self.httprequest.method == 'POST':
             # jsonp 2 steps step1 POST: save call
             def handler():
@@ -905,7 +905,7 @@ class ControllerType(type):
                                     " Will use original type: %r" % (cls.__module__, cls.__name__, k, parent_routing_type))
                 v.original_func.routing_type = routing_type or parent_routing_type
 
-                spec = inspect.getargspec(v.original_func)
+                spec = inspect.getfullargspec(v.original_func)
                 first_arg = spec.args[1] if len(spec.args) >= 2 else None
                 if first_arg in ["req", "request"]:
                     v._first_arg_is_req = True

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -5,7 +5,7 @@
 # this is important for the odoo.api.guess() that relies on signatures
 from collections import defaultdict
 from decorator import decorator
-from inspect import formatargspec, getargspec
+from inspect import formatargspec, getfullargspec
 import logging
 
 from . import pycompat
@@ -67,7 +67,7 @@ class ormcache(object):
         """ Determine the function that computes a cache key from arguments. """
         if self.skiparg is None:
             # build a string that represents function code and evaluate it
-            args = formatargspec(*getargspec(self.method))[1:-1]
+            args = formatargspec(*getfullargspec(self.method))[1:-1]
             if self.args:
                 code = "lambda %s: (%s,)" % (args, ", ".join(self.args))
             else:
@@ -115,7 +115,7 @@ class ormcache_context(ormcache):
         """ Determine the function that computes a cache key from arguments. """
         assert self.skiparg is None, "ormcache_context() no longer supports skiparg"
         # build a string that represents function code and evaluate it
-        spec = getargspec(self.method)
+        spec = getfullargspec(self.method)
         args = formatargspec(*spec)[1:-1]
         cont_expr = "(context or {})" if 'context' in spec.args else "self._context"
         keys_expr = "tuple(%s.get(k) for k in %r)" % (cont_expr, self.keys)
@@ -144,7 +144,7 @@ class ormcache_multi(ormcache):
         super(ormcache_multi, self).determine_key()
 
         # key_multi computes the extra element added to the key
-        spec = getargspec(self.method)
+        spec = getfullargspec(self.method)
         args = formatargspec(*spec)[1:-1]
         code_multi = "lambda %s: %s" % (args, self.multi)
         self.key_multi = unsafe_eval(code_multi)


### PR DESCRIPTION
# Description

Before reading, keep in mind Type Annotations are a luxury I'm trying to obtain not something that's necessary for any feature to work. You can agree with all the changes made, but still disagree to push them to the Core of Odoo if that gives you a sense of insecurity.

## Abstract

Currently if you were to use Type Annotations inside a model, you will be prompted with the following error:

```
File "/home/docker/workspace/odoo/odoo/api.py", line 112, in __new__
    value = guess(value)
File "/home/docker/workspace/odoo/odoo/api.py", line 692, in guess
    args, vname, kwname, defaults = getargspec(method)
File "/usr/lib/python3.6/inspect.py", line 1082, in getargspec
    raise ValueError("Function has keyword-only parameters or annotations"
    
ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them
```

This is because the current definition of **getargspec** will rise an error if any annotations are found. But looking at the own method documentation we can see this method is deprecated and instead tells us to use the **getfullargspec** method and even implements given method, trimming some parts of the response.

```python
def getargspec(func):
    """Get the names and default values of a function's parameters.

    A tuple of four things is returned: (args, varargs, keywords, defaults).
    'args' is a list of the argument names, including keyword-only argument names.
    'varargs' and 'keywords' are the names of the * and ** parameters or None.
    'defaults' is an n-tuple of the default values of the last n parameters.

    This function is deprecated, as it does not support annotations or
    keyword-only parameters and will raise ValueError if either is present
    on the supplied callable.

    For a more structured introspection API, use inspect.signature() instead.

    Alternatively, use getfullargspec() for an API with a similar namedtuple
    based interface, but full support for annotations and keyword-only
    parameters.

    Deprecated since Python 3.5, use `inspect.getfullargspec()`.
    """
    warnings.warn("inspect.getargspec() is deprecated since Python 3.0, "
                  "use inspect.signature() or inspect.getfullargspec()",
                  DeprecationWarning, stacklevel=2)
    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = \
        getfullargspec(func)
    if kwonlyargs or ann:
        raise ValueError("Function has keyword-only parameters or annotations"
                         ", use inspect.signature() API which can support them")
    return ArgSpec(args, varargs, varkw, defaults)
```

Changing all calls to **getargspec** to **getfullargspec** should do the trick without breaking any core functionality.

DeployV link:

## Screenshots

## Issues to Close (if applicable)

No issues closed

## Technical description (if applicable)

**getfullargspec** returns the following object

```python
FullArgSpec = namedtuple('FullArgSpec', 'args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations')
```

The first four elements of this response are the same ones **getargspec** returns, so our focus would be making sure the final three don't break anything.

## Additional considerations

If we migrate to Odoo 15 (Python 3.9), the use of **getargspec** changes in favor of **inspect.signature** which has the following definition

```python
def signature(obj, *, follow_wrapped=True):
    """Get a signature object for the passed callable."""
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped)
```

The static method **from_callable** from the class **Signature** does the following

```python
@classmethod
def from_callable(cls, obj, *, follow_wrapped=True):
    """Constructs Signature for the given callable object."""
    return _signature_from_callable(obj, sigcls=cls,
                                    follow_wrapper_chains=follow_wrapped)
```

The **_signature_from_callable** is being used also by **getfullargspec**, which unwraps the response from **_signature_from_callable**

```python
def getfullargspec(func):
    """Get the names and default values of a callable object's parameters.

    A tuple of seven things is returned:
    (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations).
    'args' is a list of the parameter names.
    'varargs' and 'varkw' are the names of the * and ** parameters or None.
    'defaults' is an n-tuple of the default values of the last n parameters.
    'kwonlyargs' is a list of keyword-only parameter names.
    'kwonlydefaults' is a dictionary mapping names from kwonlyargs to defaults.
    'annotations' is a dictionary mapping parameter names to annotations.

    Notable differences from inspect.signature():
      - the "self" parameter is always reported, even for bound methods
      - wrapper chains defined by __wrapped__ *not* unwrapped automatically
    """
    try:
        # Re: `skip_bound_arg=False`
        #
        # There is a notable difference in behaviour between getfullargspec
        # and Signature: the former always returns 'self' parameter for bound
        # methods, whereas the Signature always shows the actual calling
        # signature of the passed object.
        #
        # To simulate this behaviour, we "unbind" bound methods, to trick
        # inspect.signature to always return their first parameter ("self",
        # usually)

        # Re: `follow_wrapper_chains=False`
        #
        # getfullargspec() historically ignored __wrapped__ attributes,
        # so we ensure that remains the case in 3.3+

        sig = _signature_from_callable(func,
                                       follow_wrapper_chains=False,
                                       skip_bound_arg=False,
                                       sigcls=Signature)
    except Exception as ex:
        # Most of the times 'signature' will raise ValueError.
        # But, it can also raise AttributeError, and, maybe something
        # else. So to be fully backwards compatible, we catch all
        # possible exceptions here, and reraise a TypeError.
        raise TypeError('unsupported callable') from ex

    args = []
    varargs = None
    varkw = None
    posonlyargs = []
    kwonlyargs = []
    annotations = {}
    defaults = ()
    kwdefaults = {}

    if sig.return_annotation is not sig.empty:
        annotations['return'] = sig.return_annotation

    for param in sig.parameters.values():
        kind = param.kind
        name = param.name

        if kind is _POSITIONAL_ONLY:
            posonlyargs.append(name)
            if param.default is not param.empty:
                defaults += (param.default,)
        elif kind is _POSITIONAL_OR_KEYWORD:
            args.append(name)
            if param.default is not param.empty:
                defaults += (param.default,)
        elif kind is _VAR_POSITIONAL:
            varargs = name
        elif kind is _KEYWORD_ONLY:
            kwonlyargs.append(name)
            if param.default is not param.empty:
                kwdefaults[name] = param.default
        elif kind is _VAR_KEYWORD:
            varkw = name

        if param.annotation is not param.empty:
            annotations[name] = param.annotation

    if not kwdefaults:
        # compatibility with 'func.__kwdefaults__'
        kwdefaults = None

    if not defaults:
        # compatibility with 'func.__defaults__'
        defaults = None

    return FullArgSpec(posonlyargs + args, varargs, varkw, defaults,
                       kwonlyargs, kwdefaults, annotations)
```

## Ready to code review

- [ ] The newly added fields have help.
- [ ] The newly added methods have a docstring.
- [ ] The code has the appropriate unit tests.
- [ ] The newly added terms have a translation.
- [ ] The new methods and variables have a meaningful name.
- [ ] The code is well-designed.
- [ ] The code does what is described in the MR.
- [ ] The code isn’t more complex than it needs to be.
- [ ] The commit message [describes](https://www.odoo.com/documentation/12.0/reference/guidelines.html#commit-message-structure) the functional aim of the code.
- [ ] You added the necessary description to help the reviewer understand your changes.
- [ ] DeployV instance created and configured for review.
- [ ] You added the issues to close when this MR has been merged. (if applicable)

## Critical points to review by QA

- [ ] That nothing breaks

## QA reviewer

- [ ] @

## Code reviewers

- [ ] @